### PR TITLE
Add Flask alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Alternative versions:
 
 - [Python](https://github.com/pawurb/ecto_psql_extras)
 
+- [Flask](https://github.com/nickjj/flask-pg-extras)
+
 - [Haskell](https://github.com/pawurb/haskell-pg-extras)
 
 ## Installation


### PR DESCRIPTION
Hi,

I've been maintaining the [Flask alternative](https://github.com/nickjj/flask-pg-extras) to pg-extras for a few years now. Thought it might be nice to add to the list.

Also as a side topic, your Python alternative link is pointing towards an Elixir example.