### PR TITLE
Allow the UI to be run on rails 4

### DIFF
--- a/app/views/rails_pg_extras/web/shared/_queries_selector.html.erb
+++ b/app/views/rails_pg_extras/web/shared/_queries_selector.html.erb
@@ -1,7 +1,6 @@
-<%= form_with url: queries_path, id: "queries", method: :get do |f| %>
-  <%= f.select :query_name, options_for_select(@all_queries, params[:query_name]),
-    {prompt: "--- select query ---"},
-    {class: "border p-2 font-bold", autofocus: true}
+<%= form_tag queries_path, id: "queries", method: :get do |f| %>
+  <%= select_tag :query_name, options_for_select(@all_queries, params[:query_name]),
+    {prompt: "--- select query ---", class: "border p-2 font-bold", autofocus: true}
   %>
 <% end %>
 <script>


### PR DESCRIPTION
Uses old-school `form_tag` instead of `form_with` (which was introduced in rails 5.x) to be compatible with rails 4.x.