### PR TITLE
typo: enable_extensions -> add_extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ RailsPgExtras.configure do |config|
   # Rails-pg-extras does not enable all the web actions by default. You can check all available actions via `RailsPgExtras::Web::ACTIONS`.
   # For example, you may want to enable the dangerous `kill_all` action.
 
-  config.enabled_web_actions = %i[kill_all pg_stat_statements_reset enable_extensions]
+  config.enabled_web_actions = %i[kill_all pg_stat_statements_reset add_extensions]
 end
 ```
 

--- a/app/controllers/rails_pg_extras/web/queries_controller.rb
+++ b/app/controllers/rails_pg_extras/web/queries_controller.rb
@@ -21,7 +21,7 @@ module RailsPgExtras::Web
     private
 
     def load_queries
-      @all_queries = (RailsPgExtras::QUERIES - ACTIONS).inject({}) do |memo, query_name|
+      @all_queries = (RailsPgExtras::QUERIES - RailsPgExtras::Web::ACTIONS).inject({}) do |memo, query_name|
         unless query_name.in? %i[mandelbrot]
           memo[query_name] = { disabled: query_disabled?(query_name) }
         end

--- a/app/views/rails_pg_extras/web/queries/_unavailable_extensions_warning.html.erb
+++ b/app/views/rails_pg_extras/web/queries/_unavailable_extensions_warning.html.erb
@@ -5,7 +5,7 @@
   <% end %>
  </div>
 
-<% if RailsPgExtras::Web.action_enabled?(:enable_extensions) %>
+<% if RailsPgExtras::Web.action_enabled?(:add_extensions) %>
   <%= link_to "Enable extensions", add_extensions_action_path,
     method: "post",
     data: {

--- a/lib/rails_pg_extras/web.rb
+++ b/lib/rails_pg_extras/web.rb
@@ -2,7 +2,7 @@ require "rails_pg_extras/web/engine"
 
 module RailsPgExtras
   module Web
-    ACTIONS = %i[kill_all pg_stat_statements_reset enable_extensions].freeze
+    ACTIONS = %i[kill_all pg_stat_statements_reset add_extensions].freeze
 
     def self.action_enabled?(action_name)
       RailsPgExtras.configuration.enabled_web_actions.include?(action_name.to_sym)


### PR DESCRIPTION
This typo resulted in following error: even if you disabled "enable_extensions" via `config/initializers/rails_pg_extras.rb`, **add_extensions** was still available in dropdown (and executable).

This PR fixes that.

