### PR TITLE
run inline javascript with CSP

### DIFF
--- a/app/views/rails_pg_extras/web/shared/_queries_selector.html.erb
+++ b/app/views/rails_pg_extras/web/shared/_queries_selector.html.erb
@@ -3,8 +3,9 @@
     {prompt: "--- select query ---", class: "border p-2 font-bold", autofocus: true}
   %>
 <% end %>
-<script>
+
+<%= javascript_tag nonce: true do -%>
   document.getElementById('queries').addEventListener('change', (e) => {
     e.target.form.submit()
   })
-</script>
+<% end -%>


### PR DESCRIPTION
After I select an item, the `addEventListener` callback won't be executed since the inline script violate the CSP. I fix it by adding a nonce to the javascript tag according to [the Rails doc](https://edgeguides.rubyonrails.org/security.html#adding-a-nonce)

if a website violate CSP, you will see an similar error in console.
<img width="500" alt="image" src="https://user-images.githubusercontent.com/17806259/167755101-697605c1-39f0-4768-86c5-f499071f28cb.png">
