### PR TITLE
Update routes.rb to fix deprecation warning for future rails 8.0

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,9 @@
 RailsPgExtras::Web::Engine.routes.draw do
   resources :queries, only: [:index]
 
-  post "/actions/kill_all" => "actions#kill_all", as: :kill_all_action
-  post "/actions/pg_stat_statements_reset" => "actions#pg_stat_statements_reset", as: :pg_stat_statements_reset_action
-  post "/actions/add_extensions" => "actions#add_extensions", as: :add_extensions_action
+  post "/actions/kill_all", to: "actions#kill_all", as: :kill_all_action
+  post "/actions/pg_stat_statements_reset", to: "actions#pg_stat_statements_reset", as: :pg_stat_statements_reset_action
+  post "/actions/add_extensions", to: "actions#add_extensions", as: :add_extensions_action
 
   root to: "queries#index"
 end


### PR DESCRIPTION
This is a non breaking change and works for all recent versions of rails cf https://github.com/rails/rails/pull/52422