### PR TITLE
Detect extensions with schema prefix, too.

### DIFF
--- a/app/controllers/rails_pg_extras/web/queries_controller.rb
+++ b/app/controllers/rails_pg_extras/web/queries_controller.rb
@@ -39,8 +39,8 @@ module RailsPgExtras::Web
     def unavailable_extensions
       return @unavailable_extensions if defined?(@unavailable_extensions)
 
-      enabled_extensions = ActiveRecord::Base.connection.extensions
-      @unavailable_extensions = REQUIRED_EXTENSIONS.delete_if { |ext| ext.to_s.in?(enabled_extensions) }
+      enabled_extensions = ActiveRecord::Base.connection.extensions.lazy
+      @unavailable_extensions = REQUIRED_EXTENSIONS.delete_if { |ext| enabled_extensions.grep(/^([^.]+\.)?#{ext}$/).any? }
     end
   end
 end


### PR DESCRIPTION
If an extension is created in a different schema than the current Rails default schema, e.g. like this:

```sql
CREATE EXTENSION "pg_stat_statements" SCHEMA extensions
```

... then `ActiveRecord::Base.connection.extensions` returns the extensions with a schema prefix, e.g.

```ruby
['extensions.pg_stat_statements', 'pg_catalog.plpgsql']
```

Relevant code of `PostgreSQLAdapter`:

```ruby
internal_exec_query(query, "SCHEMA", allow_retry: true, materialize_transactions: false).cast_values.map do |row|
  name, schema = row[0], row[1]
  schema = nil if schema == current_schema
  [schema, name].compact.join(".")
end
```

Since extensions are always installed *per database*, regardless of the schema, the extension *is* available. Unfortunately rails-pg-extras no longer detects these extensions.

This commit changes the extension detection method, so that extensions with an optional schema prefix are still considered "available".

