### PR TITLE
fix: Use rails route helpers for back to diagnose link

### DIFF
--- a/app/views/rails_pg_extras/web/queries/show.html.erb
+++ b/app/views/rails_pg_extras/web/queries/show.html.erb
@@ -3,10 +3,11 @@
 
 <br>
 
-<a href="/pg_extras/queries" 
-   class="inline-block bg-blue-500 text-white font-medium px-4 py-2 rounded-lg shadow-md hover:bg-blue-600 transition">
-   ← Back to Diagnose
-</a>
+<%=
+  link_to "← Back to Diagnose", queries_path,
+          class: "inline-block bg-blue-500 text-white font-medium px-4 py-2 rounded-lg shadow-md hover:bg-blue-600 transition"
+%>
+
 <% if @error %>
   <div class="text-red-500 p-3 font-mono my-5"><%= @error %></div>
 <% else %>


### PR DESCRIPTION
I use a custom route (with authorization) in Rails, so default `/pg_extras` path is not correct in my case. Here's my setup:

``` ruby
# file: lib/middlewares/a11n.rb
module Middlewares
  class DevA11n
      include Rails.application.routes.url_helpers

    def initialize(app, ability)
      @app     = app
      @ability = ability
    end

    def call(env)
      req = ActionDispatch::Request.new(env)

      return unauthenticated(req) unless authenticated?(req)
      return forbidden(req)       unless authorized?(req)

      @app.call(env)
    end

    private

    def authenticated?(req)
      # whenever developer is authenticated
    end

    def unauthenticated(req)
      return [307, { "location" => dev_login_path(redirect_url: req.url) }, []] if req.format.html?

      [401, {}, []]
    end

    def authorized?(req)
      # whenever if authenticated developer has `ability` permissions
    end

    def forbidden(req)
      return [307, { "location" => dev_access_denied_path }, []] if req.format.html?

      [403, {}, []]
    end
  end
end

# file: config/routes/dev.rb

namespace :dev do
  a11n = ->(engine, ability) { Middlewares::DevA11n.new(engine, ability) }

  mount a11n[Sidekiq::Web,               :developer_access], at: "/sidekiq",   as: :sidekiq
  mount a11n[RailsPgExtras::Web::Engine, :developer_access], at: "/pg-extras", as: :pg_extras
end
```