### PR TITLE
build(rails): remove dependency on Rails meta-gem

### DIFF
--- a/rails-pg-extras.gemspec
+++ b/rails-pg-extras.gemspec
@@ -16,7 +16,9 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.license = "MIT"
   s.add_dependency "ruby-pg-extras", RailsPgExtras::VERSION
-  s.add_dependency "rails"
+  s.add_dependency "railties"
+  s.add_dependency "actionpack"
+  s.add_dependency "activerecord"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
   s.add_development_dependency "rufo"


### PR DESCRIPTION
We only need action controller and active record and their dependencies-- the gem has no dependency on active job, action mailer, action cable, action text, active storage, etc