### PR TITLE
Add support for ignoring false positives in missing foreign key constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,22 @@ RailsPgExtras.configure do |config|
 end
 ```
 
+You can also configure a default ignore list for the heuristic missing foreign key constraints checker. This helps skip columns that you know should not be considered foreign keys.
+
+```ruby
+RailsPgExtras.configure do |config|
+  # Accepts an Array or a comma-separated String of entries like:
+  # - "posts.category_id" (ignore a specific table+column)
+  # - "category_id"       (ignore this column name for all tables)
+  # - "posts.*"           (ignore all columns on a table)
+  # - "*"                 (ignore everything)
+  config.missing_fk_constraints_ignore_list = ["posts.category_id", "category_id"]
+
+  # Or as a comma-separated string:
+  # config.missing_fk_constraints_ignore_list = "posts.category_id, category_id"
+end
+```
+
 ## Available methods
 
 ### `measure_queries`
@@ -261,6 +277,26 @@ RailsPgExtras.missing_fk_constraints(args: { table_name: "users" })
 ```
 
 `table_name` argument is optional, if omitted, method will display missing fk constraints for all the tables.
+
+You can optionally pass an `ignore_list` to skip known false positives detected by the heuristic checker. It accepts an Array or a comma-separated String. Entries can be:
+- "posts.category_id" to ignore a specific table+column
+- "category_id" to ignore a column name for all tables
+- "posts.*" to ignore all columns on a specific table
+- "*" to ignore everything
+
+Examples:
+
+```ruby
+# Per-call ignore list
+RailsPgExtras.missing_fk_constraints(args: {
+  ignore_list: ["posts.category_id", "legacy_id", "temp_tables.*"]
+})
+
+# As a comma-separated string
+RailsPgExtras.missing_fk_constraints(args: {
+  ignore_list: "posts.category_id, legacy_id, temp_tables.*"
+})
+```
 
 ### `table_schema`
 

--- a/lib/rails-pg-extras.rb
+++ b/lib/rails-pg-extras.rb
@@ -139,7 +139,9 @@ module RailsPgExtras
   end
 
   def self.missing_fk_constraints(args: {}, in_format: :display_table)
-    result = RailsPgExtras::MissingFkConstraints.call(args[:table_name])
+    ignore_list = args[:ignore_list]
+    ignore_list ||= RailsPgExtras.configuration.missing_fk_constraints_ignore_list
+    result = RailsPgExtras::MissingFkConstraints.call(args[:table_name], ignore_list: ignore_list)
     RubyPgExtras.display_result(result, title: "Missing foreign key constraints", in_format: in_format)
   end
 

--- a/lib/rails_pg_extras/configuration.rb
+++ b/lib/rails_pg_extras/configuration.rb
@@ -4,14 +4,16 @@ require "rails_pg_extras/web"
 
 module RailsPgExtras
   class Configuration
-    DEFAULT_CONFIG = { enabled_web_actions: Web::ACTIONS - [:kill_all, :kill_pid], public_dashboard: ENV["RAILS_PG_EXTRAS_PUBLIC_DASHBOARD"] == "true" }
+    DEFAULT_CONFIG = { enabled_web_actions: Web::ACTIONS - [:kill_all, :kill_pid], public_dashboard: ENV["RAILS_PG_EXTRAS_PUBLIC_DASHBOARD"] == "true", missing_fk_constraints_ignore_list: [] }
 
     attr_reader :enabled_web_actions
     attr_accessor :public_dashboard
+    attr_accessor :missing_fk_constraints_ignore_list
 
     def initialize(attrs)
       self.enabled_web_actions = attrs[:enabled_web_actions]
       self.public_dashboard = attrs[:public_dashboard]
+      self.missing_fk_constraints_ignore_list = attrs[:missing_fk_constraints_ignore_list]
     end
 
     def enabled_web_actions=(*actions)


### PR DESCRIPTION
Fixes #58 

relies on https://github.com/pawurb/ruby-pg-extras/pull/34


the `missing_fk_constraints` method can now accept an `ignore_list` parameter, allowing users to skip known false positives.

This is set in the configure block of the gem
```ruby
RailsPgExtras.configure do |config|
  # Accepts an Array or a comma-separated String of entries like:
  # - "posts.category_id" (ignore a specific table+column)
  # - "category_id"       (ignore this column name for all tables)
  # - "posts.*"           (ignore all columns on a table)
  # - "*"                 (ignore everything)
  config.missing_fk_constraints_ignore_list = ["posts.category_id", "category_id"]

  # Or as a comma-separated string:
  # config.missing_fk_constraints_ignore_list = "posts.category_id, category_id"
end
