### PR TITLE
Update readme database config + Fix "Back to diagnose

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ you can add this info to the output:
 
 ### `missing_fk_indexes`
 
-This method lists columns likely to be foreign keys (i.e. column name ending in `_id` and related table exists) which don't have an index. It's recommended to always index foreign key columns because they are used for searching relation objects. 
+This method lists **actual foreign key columns** (based on existing foreign key constraints) which don't have a supporting index. It's recommended to always index foreign key columns because they are commonly used for lookups and join conditions.
 
 You can add indexes on the columns returned by this query and later check if they are receiving scans using the [unused_indexes method](#unused_indexes). Please remember that each index decreases write performance and autovacuuming overhead, so be careful when adding multiple indexes to often updated tables.
 
@@ -270,10 +270,20 @@ RailsPgExtras.missing_fk_indexes(args: { table_name: "users" })
 
 ## `missing_fk_constraints`
 
-Similarly to the previous method, this one shows columns likely to be foreign keys that don't have a corresponding foreign key constraint. Foreign key constraints improve data integrity in the database by preventing relations with nonexisting objects. You can read more about the benefits of using foreign keys [in this blog post](https://pawelurbanek.com/rails-postgresql-data-integrity).
+This method shows **columns that look like foreign keys** but don't have a corresponding foreign key constraint yet. Foreign key constraints improve data integrity in the database by preventing relations with nonexisting objects. You can read more about the benefits of using foreign keys [in this blog post](https://pawelurbanek.com/rails-postgresql-data-integrity).
+
+Heuristic notes:
+- A column is considered a candidate if it matches `<table_singular>_id` and the related table exists (underscored prefixes like `account_user_id` are supported).
+- Rails polymorphic associations (`<name>_id` + `<name>_type`) are ignored since they cannot be expressed as real FK constraints.
+
+You can also exclude known/intentional cases using `ignore_list` (array or comma-separated string), with entries like:
+- "posts.category_id" (ignore a specific table+column)
+- "category_id" (ignore this column name for all tables)
+- "posts.*" (ignore all columns on a table)
+- "*" (ignore everything)
 
 ```ruby
-RailsPgExtras.missing_fk_constraints(args: { table_name: "users" })
+RailsPgExtras.missing_fk_constraints(args: { table_name: "users", ignore_list: ["users.customer_id", "posts.*"] })
 
 +---------------------------------+
 | Missing foreign key constraints |
@@ -287,12 +297,6 @@ RailsPgExtras.missing_fk_constraints(args: { table_name: "users" })
 ```
 
 `table_name` argument is optional, if omitted, method will display missing fk constraints for all the tables.
-
-You can optionally pass an `ignore_list` to skip known false positives detected by the heuristic checker. It accepts an Array or a comma-separated String. Entries can be:
-- "posts.category_id" to ignore a specific table+column
-- "category_id" to ignore a column name for all tables
-- "posts.*" to ignore all columns on a specific table
-- "*" to ignore everything
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,17 @@ You should see the similar line in the output:
 RailsPgExtras.add_extensions
 ```
 
-By default a primary ActiveRecord database connection is used for running metadata queries, rake tasks and web UI. To connect to a different database you can specify an `ENV['RAILS_PG_EXTRAS_DATABASE_URL']` value in the following format:
+By default rails-pg-extras uses your app’s default `ActiveRecord::Base.connection` (typically `primary`) for running metadata queries, rake tasks and the web UI.
+
+If your app uses Rails multiple databases, the web UI can switch connections dynamically. It reads the available database names from `ActiveRecord::Base.configurations` for the current environment and selects one via the `db_key` query param (thread-local per request, so it’s safe under concurrency):
+
+```ruby
+# examples
+/pg_extras?db_key=primary
+/pg_extras?db_key=animals
+```
+
+To connect to a database that isn’t defined in `database.yml` (or when using rake tasks / Ruby API outside the web UI), you can also provide an explicit URL via `ENV['RAILS_PG_EXTRAS_DATABASE_URL']`:
 
 ```ruby
 ENV["RAILS_PG_EXTRAS_DATABASE_URL"] = "postgresql://postgres:secret@localhost:5432/database_name"

--- a/app/views/rails_pg_extras/web/queries/show.html.erb
+++ b/app/views/rails_pg_extras/web/queries/show.html.erb
@@ -3,7 +3,8 @@
 
 <br>
 
-<%= link_to "← Back to Diagnose", queries_path,
+<%= link_to "← Back to Diagnose",
+            queries_path(params[:db_key].present? ? { db_key: params[:db_key] } : {}),
             class: "inline-block bg-blue-500 text-white font-medium px-4 py-2 rounded-lg shadow-md hover:bg-blue-600 transition" %>
 
 <% if @error %>


### PR DESCRIPTION
- Update the README to inform about the multiple database support introduced in https://github.com/pawurb/rails-pg-extras/pull/60/

- fix an issue with the back to diagnose, that loses the query_param, which can be annoying