### PR TITLE
Rename database_url to database_config, explain you can also specify a specific (pre-configured) database configuration with it

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Optionally you can enable a visual interface:
 
 ![Web interface](https://github.com/pawurb/rails-pg-extras/raw/main/pg-extras-ui-3.png)
 
-[rails-pg-extras-mcp gem](https://github.com/pawurb/rails-pg-extras-mcp) provides an MCP (Model Context Protocol) interface enabling PostgreSQL metadata and performance analysis with an LLM support.  
+[rails-pg-extras-mcp gem](https://github.com/pawurb/rails-pg-extras-mcp) provides an MCP (Model Context Protocol) interface enabling PostgreSQL metadata and performance analysis with an LLM support.
 
 ![LLM interface](https://github.com/pawurb/rails-pg-extras/raw/main/pg-extras-mcp.png)
 
@@ -67,16 +67,17 @@ If your app uses Rails multiple databases, the web UI can switch connections dyn
 /pg_extras?db_key=animals
 ```
 
-To connect to a database that isn’t defined in `database.yml` (or when using rake tasks / Ruby API outside the web UI), you can also provide an explicit URL via `ENV['RAILS_PG_EXTRAS_DATABASE_URL']`:
+To connect to a database that isn’t defined in `database.yml` (or when using rake tasks / Ruby API outside the web UI), you can also provide an explicit URL via `ENV['RAILS_PG_EXTRAS_DATABASE_CONFIG']`:
 
 ```ruby
-ENV["RAILS_PG_EXTRAS_DATABASE_URL"] = "postgresql://postgres:secret@localhost:5432/database_name"
+ENV["RAILS_PG_EXTRAS_DATABASE_CONFIG"] = "postgresql://postgres:secret@localhost:5432/database_name"
 ```
 
-Alternatively, you can specify database URL with a method call:
+Alternatively, you can specify database configuration with a method call:
 
 ```ruby
-RailsPgExtras.database_url = "postgresql://postgres:secret@localhost:5432/database_name"
+RailsPgExtras.database_config = "postgresql://postgres:secret@localhost:5432/database_name"
+RailsPgExtras.database_config = :rails_pg_extras
 ```
 
 ## Usage
@@ -547,7 +548,7 @@ $ rake pg_extras:calls
 (truncated results for brevity)
 ```
 
-This command is much like `pg:outliers`, but ordered by the number of times a statement has been called. 
+This command is much like `pg:outliers`, but ordered by the number of times a statement has been called.
 
 [More info](https://pawelurbanek.com/postgresql-fix-performance#missing-indexes)
 

--- a/spec/smoke_spec.rb
+++ b/spec/smoke_spec.rb
@@ -40,15 +40,29 @@ describe RailsPgExtras do
     expect(output.fetch(:count) > 0).to eq(true)
   end
 
+  it "supports custom RAILS_PG_EXTRAS_DATABASE_CONFIG that specifies an URL" do
+    old_value = ENV["RAILS_PG_EXTRAS_DATABASE_CONFIG"]
+    ENV["RAILS_PG_EXTRAS_DATABASE_CONFIG"] = ENV["DATABASE_URL"]
+    puts ENV["RAILS_PG_EXTRAS_DATABASE_CONFIG"]
+
+    expect do
+      RailsPgExtras.calls
+    end.not_to raise_error
+  ensure
+    ENV["RAILS_PG_EXTRAS_DATABASE_CONFIG"] = old_value
+  end
+
+  # Deprecated
   it "supports custom RAILS_PG_EXTRAS_DATABASE_URL" do
+    old_value = ENV["RAILS_PG_EXTRAS_DATABASE_URL"]
     ENV["RAILS_PG_EXTRAS_DATABASE_URL"] = ENV["DATABASE_URL"]
     puts ENV["RAILS_PG_EXTRAS_DATABASE_URL"]
 
     expect do
       RailsPgExtras.calls
     end.not_to raise_error
-
-    ENV["RAILS_PG_EXTRAS_DATABASE_URL"] = nil
+  ensure
+    ENV["RAILS_PG_EXTRAS_DATABASE_URL"] = old_value
   end
 
   describe "missing_fk_indexes" do
@@ -67,14 +81,30 @@ describe RailsPgExtras do
     end
   end
 
-  it "database_url does not affect global connection" do
+  it "database_config does not affect global connection" do
     original_connection = ActiveRecord::Base.connection
 
-    RailsPgExtras.database_url = ENV["DATABASE_URL"]
+    old_value = RailsPgExtras.database_config
+    RailsPgExtras.database_config = ENV["DATABASE_URL"]
     RailsPgExtras.calls
-    RailsPgExtras.database_url = nil
 
     # Verify global connection unchanged
     expect(ActiveRecord::Base.connection).to eq(original_connection)
+  ensure
+    RailsPgExtras.database_config = old_value
+  end
+
+  # Deprecated
+  it "database_url does not affect global connection" do
+    original_connection = ActiveRecord::Base.connection
+
+    old_value = RailsPgExtras.database_url
+    RailsPgExtras.database_url = ENV["DATABASE_URL"]
+    RailsPgExtras.calls
+
+    # Verify global connection unchanged
+    expect(ActiveRecord::Base.connection).to eq(original_connection)
+  ensure
+    RailsPgExtras.database_url = old_value
   end
 end


### PR DESCRIPTION
This works because `ActiveRecord::Base.establish_connection` accepts both URLs, full database configurations, and symbols specifying pre-configured database configurations.

Ref https://github.com/pawurb/rails-pg-extras/issues/62.