### PR TITLE
Rename database_url to database_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Optionally you can enable a visual interface:
 
 ![Web interface](https://github.com/pawurb/rails-pg-extras/raw/main/pg-extras-ui-3.png)
 
-[rails-pg-extras-mcp gem](https://github.com/pawurb/rails-pg-extras-mcp) provides an MCP (Model Context Protocol) interface enabling PostgreSQL metadata and performance analysis with an LLM support.  
+[rails-pg-extras-mcp gem](https://github.com/pawurb/rails-pg-extras-mcp) provides an MCP (Model Context Protocol) interface enabling PostgreSQL metadata and performance analysis with an LLM support.
 
 ![LLM interface](https://github.com/pawurb/rails-pg-extras/raw/main/pg-extras-mcp.png)
 
@@ -67,16 +67,17 @@ If your app uses Rails multiple databases, the web UI can switch connections dyn
 /pg_extras?db_key=animals
 ```
 
-To connect to a database that isn’t defined in `database.yml` (or when using rake tasks / Ruby API outside the web UI), you can also provide an explicit URL via `ENV['RAILS_PG_EXTRAS_DATABASE_URL']`:
+To connect to a database that isn’t defined in `database.yml` (or when using rake tasks / Ruby API outside the web UI), you can also provide an explicit URL via `ENV['RAILS_PG_EXTRAS_DATABASE_CONFIG']`:
 
 ```ruby
-ENV["RAILS_PG_EXTRAS_DATABASE_URL"] = "postgresql://postgres:secret@localhost:5432/database_name"
+ENV["RAILS_PG_EXTRAS_DATABASE_CONFIG"] = "postgresql://postgres:secret@localhost:5432/database_name"
 ```
 
-Alternatively, you can specify database URL with a method call:
+Alternatively, you can specify database configuration with a method call:
 
 ```ruby
-RailsPgExtras.database_url = "postgresql://postgres:secret@localhost:5432/database_name"
+RailsPgExtras.database_config = "postgresql://postgres:secret@localhost:5432/database_name"
+RailsPgExtras.database_config = :rails_pg_extras
 ```
 
 ## Usage
@@ -559,7 +560,7 @@ $ rake pg_extras:calls
 (truncated results for brevity)
 ```
 
-This command is much like `pg:outliers`, but ordered by the number of times a statement has been called. 
+This command is much like `pg:outliers`, but ordered by the number of times a statement has been called.
 
 [More info](https://pawelurbanek.com/postgresql-fix-performance#missing-indexes)
 

--- a/lib/rails-pg-extras.rb
+++ b/lib/rails-pg-extras.rb
@@ -12,7 +12,10 @@ require "rails_pg_extras/table_info"
 require "rails_pg_extras/table_info_print"
 
 module RailsPgExtras
-  @@database_url = nil
+  extend self
+
+  @@database_config = nil
+
   QUERIES = RubyPgExtras::QUERIES
   DEFAULT_ARGS = RubyPgExtras::DEFAULT_ARGS
   NEW_PG_STAT_STATEMENTS = RubyPgExtras::NEW_PG_STAT_STATEMENTS
@@ -28,7 +31,7 @@ module RailsPgExtras
     end
   end
 
-  def self.run_query(query_name:, in_format:, args: {})
+  def run_query(query_name:, in_format:, args: {})
     RubyPgExtras.run_query_base(
       query_name: query_name,
       conn: connection,
@@ -38,7 +41,7 @@ module RailsPgExtras
     )
   end
 
-  def self.diagnose(in_format: :display_table)
+  def diagnose(in_format: :display_table)
     data = RailsPgExtras::DiagnoseData.call
 
     if in_format == :display_table
@@ -50,14 +53,14 @@ module RailsPgExtras
     end
   end
 
-  def self.measure_duration(&block)
+  def measure_duration(&block)
     starting = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     block.call
     ending = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     (ending - starting) * 1000
   end
 
-  def self.measure_queries(&block)
+  def measure_queries(&block)
     queries = {}
     sql_duration = 0
 
@@ -105,7 +108,7 @@ module RailsPgExtras
     }
   end
 
-  def self.index_info(args: {}, in_format: :display_table)
+  def index_info(args: {}, in_format: :display_table)
     data = RailsPgExtras::IndexInfo.call(args[:table_name])
 
     if in_format == :display_table
@@ -119,7 +122,7 @@ module RailsPgExtras
     end
   end
 
-  def self.table_info(args: {}, in_format: :display_table)
+  def table_info(args: {}, in_format: :display_table)
     data = RailsPgExtras::TableInfo.call(args[:table_name])
 
     if in_format == :display_table
@@ -133,79 +136,82 @@ module RailsPgExtras
     end
   end
 
-  def self.missing_fk_indexes(args: {}, in_format: :display_table)
+  def missing_fk_indexes(args: {}, in_format: :display_table)
     ignore_list = args[:ignore_list]
     ignore_list ||= RailsPgExtras.configuration.missing_fk_indexes_ignore_list
     result = RailsPgExtras::MissingFkIndexes.call(args[:table_name], ignore_list: ignore_list)
     RubyPgExtras.display_result(result, title: "Missing foreign key indexes", in_format: in_format)
   end
 
-  def self.missing_fk_constraints(args: {}, in_format: :display_table)
+  def missing_fk_constraints(args: {}, in_format: :display_table)
     ignore_list = args[:ignore_list]
     ignore_list ||= RailsPgExtras.configuration.missing_fk_constraints_ignore_list
     result = RailsPgExtras::MissingFkConstraints.call(args[:table_name], ignore_list: ignore_list)
     RubyPgExtras.display_result(result, title: "Missing foreign key constraints", in_format: in_format)
   end
 
-  def self.database_url=(value)
-    @@database_url = value
+  def database_config
+    @@database_config
   end
 
-  def self.connection
+  # Deprecated
+  alias_method :database_url, :database_config
+
+  def database_config=(value)
+    @@database_config = value
+  end
+
+  # Deprecated
+  alias_method :database_url=, :database_config=
+
+  def connection
     # Priority:
     # 1) Per-request selected db (thread-local), if present -> use named configuration or URL without altering global Base
-    # 2) Explicit URL via setter or ENV override
+    # 2) Explicit config via setter or ENV override
     # 3) Default ActiveRecord::Base connection
     selected_db_key = Thread.current[:rails_pg_extras_db_key]
-    db_url = @@database_url || ENV["RAILS_PG_EXTRAS_DATABASE_URL"]
+    config = @@database_config || ENV["RAILS_PG_EXTRAS_DATABASE_CONFIG"] || ENV["RAILS_PG_EXTRAS_DATABASE_URL"] # Latter is deprecated
 
     if selected_db_key.present?
-      const_name = selected_db_key.classify
-      # Use an isolated abstract class to avoid changing the global connection
-      thread_classes = (Thread.current[:rails_pg_extras_ar_classes] ||= {})
-      ar_class = (thread_classes[selected_db_key] ||= begin
-        if const_defined?(const_name, false)
-          const_get(const_name, false)
-        else
-          klass = Class.new(ActiveRecord::Base)
-          klass.abstract_class = true
-          const_set(const_name, klass)
-        end
-      end)
+      # Prefix thread class key to avoid collisions
+      ar_class = fetch_or_define_ar_class(thread_class_key: "database_#{selected_db_key}", const_name: selected_db_key.classify)
 
-      connector = ar_class.establish_connection(selected_db_key.to_sym)
+      establish_connection(ar_class: ar_class, config: selected_db_key.to_sym)
+    elsif config.present?
+      ar_class = fetch_or_define_ar_class(thread_class_key: :database_config, const_name: :PgExtrasDatabaseConfig)
 
-      if connector.respond_to?(:connection)
-        connector.connection
-      elsif connector.respond_to?(:lease_connection)
-        connector.lease_connection
-      else
-        raise "Unsupported connector: #{connector.class}"
-      end
-    elsif db_url.present?
-      # Use an isolated abstract class to avoid changing the global connection
-      thread_classes = (Thread.current[:rails_pg_extras_ar_classes] ||= {})
-      ar_class = (thread_classes[:database_url] ||= begin
-        if const_defined?(:PgExtrasURLConn, false)
-          const_get(:PgExtrasURLConn, false)
-        else
-          klass = Class.new(ActiveRecord::Base)
-          klass.abstract_class = true
-          const_set(:PgExtrasURLConn, klass)
-        end
-      end)
-
-      connector = ar_class.establish_connection(db_url)
-
-      if connector.respond_to?(:connection)
-        connector.connection
-      elsif connector.respond_to?(:lease_connection)
-        connector.lease_connection
-      else
-        raise "Unsupported connector: #{connector.class}"
-      end
+      establish_connection(ar_class: ar_class, config: config)
     else
       ActiveRecord::Base.connection
+    end
+  end
+
+  private
+
+  # Use an isolated abstract class to avoid changing the global connection
+  def fetch_or_define_ar_class(thread_class_key:, const_name:)
+    thread_classes = Thread.current[:rails_pg_extras_ar_classes] ||= {}
+
+    thread_classes[thread_class_key] ||=
+      if const_defined?(const_name, false)
+        const_get(const_name, false)
+      else
+        klass = Class.new(ActiveRecord::Base)
+        klass.abstract_class = true
+
+        const_set(const_name, klass)
+      end
+  end
+
+  def establish_connection(ar_class:, config:)
+    connector = ar_class.establish_connection(config)
+
+    if connector.respond_to?(:connection)
+      connector.connection
+    elsif connector.respond_to?(:lease_connection)
+      connector.lease_connection
+    else
+      raise "Unsupported connector: #{connector.class}"
     end
   end
 end

--- a/spec/smoke_spec.rb
+++ b/spec/smoke_spec.rb
@@ -40,15 +40,29 @@ describe RailsPgExtras do
     expect(output.fetch(:count) > 0).to eq(true)
   end
 
+  it "supports custom RAILS_PG_EXTRAS_DATABASE_CONFIG that specifies an URL" do
+    old_value = ENV["RAILS_PG_EXTRAS_DATABASE_CONFIG"]
+    ENV["RAILS_PG_EXTRAS_DATABASE_CONFIG"] = ENV["DATABASE_URL"]
+    puts ENV["RAILS_PG_EXTRAS_DATABASE_CONFIG"]
+
+    expect do
+      RailsPgExtras.calls
+    end.not_to raise_error
+  ensure
+    ENV["RAILS_PG_EXTRAS_DATABASE_CONFIG"] = old_value
+  end
+
+  # Deprecated
   it "supports custom RAILS_PG_EXTRAS_DATABASE_URL" do
+    old_value = ENV["RAILS_PG_EXTRAS_DATABASE_URL"]
     ENV["RAILS_PG_EXTRAS_DATABASE_URL"] = ENV["DATABASE_URL"]
     puts ENV["RAILS_PG_EXTRAS_DATABASE_URL"]
 
     expect do
       RailsPgExtras.calls
     end.not_to raise_error
-
-    ENV["RAILS_PG_EXTRAS_DATABASE_URL"] = nil
+  ensure
+    ENV["RAILS_PG_EXTRAS_DATABASE_URL"] = old_value
   end
 
   describe "missing_fk_indexes" do
@@ -67,14 +81,30 @@ describe RailsPgExtras do
     end
   end
 
-  it "database_url does not affect global connection" do
+  it "database_config does not affect global connection" do
     original_connection = ActiveRecord::Base.connection
 
-    RailsPgExtras.database_url = ENV["DATABASE_URL"]
+    old_value = RailsPgExtras.database_config
+    RailsPgExtras.database_config = ENV["DATABASE_URL"]
     RailsPgExtras.calls
-    RailsPgExtras.database_url = nil
 
     # Verify global connection unchanged
     expect(ActiveRecord::Base.connection).to eq(original_connection)
+  ensure
+    RailsPgExtras.database_config = old_value
+  end
+
+  # Deprecated
+  it "database_url does not affect global connection" do
+    original_connection = ActiveRecord::Base.connection
+
+    old_value = RailsPgExtras.database_url
+    RailsPgExtras.database_url = ENV["DATABASE_URL"]
+    RailsPgExtras.calls
+
+    # Verify global connection unchanged
+    expect(ActiveRecord::Base.connection).to eq(original_connection)
+  ensure
+    RailsPgExtras.database_url = old_value
   end
 end


### PR DESCRIPTION
This works because `ActiveRecord::Base.establish_connection accepts both URLs, full database configurations, and symbols specifying pre-configured database configurations.