### PR TITLE
Preserve selected database for web actions

### DIFF
--- a/app/views/rails_pg_extras/web/queries/_unavailable_extensions_warning.html.erb
+++ b/app/views/rails_pg_extras/web/queries/_unavailable_extensions_warning.html.erb
@@ -6,10 +6,10 @@
  </div>
 
 <% if RailsPgExtras::Web.action_enabled?(:add_extensions) %>
-  <%= link_to "Enable extensions", add_extensions_action_path,
+  <% action_params = params[:db_key].present? ? { db_key: params[:db_key] } : {} %>
+  <%= link_to "Enable extensions", add_extensions_action_path(action_params),
               method: "post",
               data: {
                 confirm: "This command will enable following extensions: #{unavailable_extensions.keys.join(", ")}. Do you want to proceeed?",
               }, class: "border p-3 bg-green-500 text-white hover:bg-green-600 font-bold rounded" %>
 <% end %>
-

--- a/app/views/rails_pg_extras/web/queries/index.html.erb
+++ b/app/views/rails_pg_extras/web/queries/index.html.erb
@@ -6,9 +6,10 @@
 <br>
 <br>
 <h1 class="font-bold text-xl my-5">Actions</h1>
+<% action_params = params[:db_key].present? ? { db_key: params[:db_key] } : {} %>
 
 <% if RailsPgExtras::Web.action_enabled?(:kill_all) %>
-  <%= link_to "kill_all", kill_all_action_path,
+  <%= link_to "kill_all", kill_all_action_path(action_params),
               method: "post",
               data: {
                 confirm: "This commands kills all the currently active connections to the database. Do you want to proceed?",
@@ -17,7 +18,7 @@
 <% end %>
 
 <% if RailsPgExtras::Web.action_enabled?(:pg_stat_statements_reset) && unavailable_extensions.exclude?(:pg_stat_statements) %>
-  <%= link_to "pg_stat_statements_reset", pg_stat_statements_reset_action_path,
+  <%= link_to "pg_stat_statements_reset", pg_stat_statements_reset_action_path(action_params),
               method: "post",
               data: {
                 confirm: "This command discards all statistics gathered so far by pg_stat_statements. Do you want to proceed?",


### PR DESCRIPTION
`db_key` is now included in web action links when a database is selected, so actions like `kill_all`, `pg_stat_statements_reset`, and `add_extensions` run against the same database currently shown in the dashboard

cc @pawurb followup to my original work on multi database support ( Hopefully the last one 🙏🏼 )